### PR TITLE
Fix hotkeys working everywhere for windows

### DIFF
--- a/keymaps/isearch.cson
+++ b/keymaps/isearch.cson
@@ -5,7 +5,7 @@
   'cmd-i': 'incremental-search:forward'
   'shift-cmd-i': 'incremental-search:backward'
 
-'.platform-win32,.platform-linux atom-workspace atom-text-editor:not(.mini)':
+'.platform-win32 atom-workspace atom-text-editor:not(.mini), .platform-linux atom-workspace atom-text-editor:not(.mini)':
   'ctrl-i': 'incremental-search:forward'
   'shift-ctrl-i': 'incremental-search:backward'
 


### PR DESCRIPTION
The ctrl-i hotkeys worked everywhere for Windows. They should only work in atom-workspace atom-text-editor:not(.mini).