### PR TITLE
Prevent <atom-panel> pileup after multiple searches

### DIFF
--- a/lib/input-view.coffee
+++ b/lib/input-view.coffee
@@ -96,6 +96,7 @@ class InputView extends View
     @hideAllTooltips()
     workspaceElement = atom.views.getView(atom.workspace)
     workspaceElement.focus()
+    @inputPanel?.destroy()
     super()
 
   trigger: (direction) ->
@@ -141,7 +142,6 @@ class InputView extends View
 
   cancelSearch: ->
     @searchModel.cancelSearch()
-    @inputPanel?.hide()
     @detach()
 
   updateOptionsLabel: ->


### PR DESCRIPTION
`InputView` was inconsistent with its creation and destruction of `@inputPanel` -- if the View was detached, it would always create a new input panel. When a search was finished (with `core:close` or `core:cancel`), the view was detached, but the panel that had been created wasn't removed. (In the `core:cancel` case, it was at least hidden.)

This led to a pile of empty `<atom-panel>` elements.

It was easier to destroy and recreate the panel every time instead of trying to keep it around, but hiding it and showing it (and only creating it once) would be another solution to the problem.
