### PR TITLE
Add option to land at a point instead of a range

### DIFF
--- a/lib/search-model.coffee
+++ b/lib/search-model.coffee
@@ -149,12 +149,17 @@ class SearchModel
 
   moveCursorToCurrent: ->
     # Move the cursor to the current result (or last result if there are none now).
-    if @lastPosition
+    return unless @lastPosition
+    doLandAtPoint = atom.config.get('incremental-search.landAtPointInsteadOfRange')
+
+    if doLandAtPoint
       if @direction == 'forward'
         lastPositionPoint = [@lastPosition.end, @lastPosition.end]
       else
         lastPositionPoint = [@lastPosition.start, @lastPosition.start]
       @editSession.setSelectedBufferRange(lastPositionPoint)
+    else
+      @editSession.setSelectedBufferRange(@lastPosition)
 
   cancelSearch: ->
     if @startMarker

--- a/lib/search-model.coffee
+++ b/lib/search-model.coffee
@@ -150,7 +150,11 @@ class SearchModel
   moveCursorToCurrent: ->
     # Move the cursor to the current result (or last result if there are none now).
     if @lastPosition
-      @editSession.setSelectedBufferRange(@lastPosition)
+      if @direction == 'forward'
+        lastPositionPoint = [@lastPosition.end, @lastPosition.end]
+      else
+        lastPositionPoint = [@lastPosition.start, @lastPosition.start]
+      @editSession.setSelectedBufferRange(lastPositionPoint)
 
   cancelSearch: ->
     if @startMarker

--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
       "type": "boolean",
       "default": true,
       "description": "Keep the values of the Match Case and Use Regex options between searches."
+    },
+    "landAtPointInsteadOfRange": {
+      "type": "boolean",
+      "default": false,
+      "description": "Leave your cursor at a single point instead of selecting your search term."
     }
   }
 }


### PR DESCRIPTION
As a long-time emacs user, I can't live without incremental search, so this package makes atom viable for me.  The only thing breaking my navigation flow was landing at a selection.

This collapses the range to points based on direction, and leaves it as an option for each user.  I imagine others will find it useful.