### PR TITLE
Fix 2 deprecations (#65, #66)

### DIFF
--- a/lib/search-model.coffee
+++ b/lib/search-model.coffee
@@ -90,13 +90,8 @@ class SearchModel
 
       @subscriptions.add @changeSubscription
 
-      markerAttributes =
-        invalidate: 'inside'
-        replicate: false
-        persistent: false
-        isCurrent: false
       range = @editSession.getSelectedBufferRange()
-      @startMarker = @editSession.markBufferRange(range, markerAttributes)
+      @startMarker = @editSession.markBufferRange(range, invalidate: 'inside')
 
       @updateMarkers()
 
@@ -304,13 +299,7 @@ class SearchModel
       normalSearchRegex
 
   createMarker: (range) ->
-    markerAttributes =
-      class: @constructor.resultClass
-      invalidate: 'inside'
-      replicate: false
-      persistent: false
-      isCurrent: false
-    marker = @editSession.markBufferRange(range, markerAttributes)
+    marker = @editSession.markBufferRange(range, invalidate: 'inside')
     decoration = @editSession.decorateMarker(marker, type: 'highlight', class: @constructor.resultClass)
     marker
 

--- a/styles/isearch.less
+++ b/styles/isearch.less
@@ -25,14 +25,12 @@
 // I'm defaulting to the same values that the find-and-replace package is using since they are
 // the same concept.  I want this package to work seamlessly with that one.
 
-atom-text-editor::shadow .isearch-result .region,
 atom-text-editor .isearch-result .region {
   background-color: transparent;
   border-radius: @component-border-radius;
   border: 1px solid @syntax-result-marker-color;
 }
 
-atom-text-editor::shadow .isearch-current .region,
 atom-text-editor .isearch-current .region {
   background-color: transparent;
   border-radius: @component-border-radius;


### PR DESCRIPTION
Fix "Deprecated selector in `incremental-search/styles/isearch.less`"  - #66 and "Assigning custom properties to a marker when creating/copying it is deprecated." - #65  deprecations